### PR TITLE
Fixing documentation to correctly document milliseconds, not seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Bower requires [Node](http://nodejs.org/) and [npm](http://npmjs.org/).
 #### API
 
 ```javascript
-//Display the Arrow for 6 seconds
+//Display the Arrow for 5 seconds
 //
-//@param seconds {integer} Show the arrow for this many seconds then fade out. It is optional
-Arrow.show();
+//@param milliseconds {integer} Show the arrow for this many milliseconds then fade
+//out. Defaults to 6000 milliseconds (6 seconds)
+Arrow.show(5000);
 ```
 
 #### Properties

--- a/src/js/arrow.js
+++ b/src/js/arrow.js
@@ -45,7 +45,7 @@ window.Arrow = (function (window, document, undefined) {
      * @method _increaseOpacity
      * @private
      */
-    function _increaseOpacity(seconds) {
+    function _increaseOpacity(milliseconds) {
         var arrow = document.getElementById('arrow-' + browser);
         arrow.style.display = 'block';
         var i = 0.0,
@@ -66,7 +66,7 @@ window.Arrow = (function (window, document, undefined) {
         }, 600);
         setTimeout(function() {
             _hide();
-        }, seconds || 6000);
+        }, milliseconds || 6000);
         // TODO use requestAnimationFrame - http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
     }
 


### PR DESCRIPTION
Also smooths out API documentation a bit to make it more obvious how to
use the function.
